### PR TITLE
fix: only add the first line of the commit to the release notes

### DIFF
--- a/pyuploadtool/changelog/commit.py
+++ b/pyuploadtool/changelog/commit.py
@@ -18,6 +18,7 @@ class ChangelogEntry:
         ChangelogEntry instance
         """
         author = Author(name=commit.author.name, email=commit.author.email)
-        message = commit.commit.message
+        # only get the first line of the commit
+        message = commit.commit.message.split("\n")[0]
         sha = commit.sha
         return ChangelogEntry(author=author, message=message, sha=sha)

--- a/pyuploadtool/changelog/parsers/markdown.py
+++ b/pyuploadtool/changelog/parsers/markdown.py
@@ -20,10 +20,11 @@ class MarkdownChangelogParser(ChangelogParser):
                 markdown_changelog.append(f"## {self.changelog.structure().get(spec)}")
 
             for commit in self.changelog[spec]:
+                commit_link_text = commit.author.name if commit.author.name is not None else commit.sha[:7]
                 if self.commit_link_prefix:
-                    author = f"([{commit.author.name}]({self.commit_link_prefix}/{commit.sha}))"
+                    author = f"([{commit_link_text}]({self.commit_link_prefix}/{commit.sha}))"
                 else:
-                    author = f"({commit.author.name})"
+                    author = f"({commit_link_text})"
 
                 markdown_changelog.append(f"* {commit.message} {author}")
 


### PR DESCRIPTION
Multiline commits could make the release notes markdown unreadable.
We should only use the first line of the commit message in the release notes